### PR TITLE
Fix: Bundle Jars-in-Jars directly in jar task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,6 +224,11 @@ tasks.jar {
     from("LICENSE") {
         rename { "${it}_${properties["archivesBaseName"]}"}
     }
+    
+    // Explicitly bundle included dependencies (Jars-in-Jars) into the standard jar
+    into("META-INF/jars") {
+        from(configurations.named("include"))
+    }
 }
 
 // configure the maven publication


### PR DESCRIPTION
Publishing the jar artifact directly misses the Jars-in-Jars (JiJ) bundling that was previously handled by remapJar. This configures the standard jar task to include the nested dependencies in META-INF/jars so they are bundled successfully.